### PR TITLE
feat: add 'validateStatus' to axios request config

### DIFF
--- a/packages/plugin-client/src/clients/axios.ts
+++ b/packages/plugin-client/src/clients/axios.ts
@@ -16,6 +16,7 @@ export type RequestConfig<TData = unknown> = {
   data?: TData | FormData
   responseType?: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream'
   signal?: AbortSignal
+  validateStatus?: (status: number) => boolean
   headers?: AxiosRequestConfig['headers']
 }
 


### PR DESCRIPTION
When uploading files, we also check whether a file already exists (which returns `409 Conflict`). We do not want `axios` throwing an error, and to achieve this, we rely on `validateStatus`:

```ts
const response = await upload(
  { file },
  { param1 },
  {
    // Validate status "409 Conflict"
    validateStatus: (status) => status === 409 || (status >= 200 && status < 300),
  },
);
```

Right now, `validateStatus` is not part of the corresponding `RequestConfig`, which we're requesting to add with this PR! 🙏 